### PR TITLE
Use reference in video type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "subscriber"
 path = "src/main_subscriber.rs"
 
 [dependencies]
-dust_dds = { version = "0.9" }
+dust_dds = { version = "0.10", git = "https://github.com/s2e-systems/dust-dds", branch = "main"}
 gstreamer = "0.22.4"
 gstreamer-app = "0.22.0"
 

--- a/android/publisher/Cargo.toml
+++ b/android/publisher/Cargo.toml
@@ -19,6 +19,6 @@ gstreamer-app = "0.22.0"
 gstreamer-video = "0.22.4"
 gstreamer-video-sys = "0.22.1"
 glib = "0.19.5"
-dust_dds = { version = "0.9" }
+dust_dds = { version = "0.10", git = "https://github.com/s2e-systems/dust-dds", branch = "main"}
 jni = { version = "0.21.1", default-features = false }
 ndk-sys = "0.6.0"

--- a/android/publisher/build.gradle
+++ b/android/publisher/build.gradle
@@ -13,8 +13,6 @@ tasks.register('configure_gstreamer_java', Copy) {
     from "${System.env.GSTREAMER_1_0_ROOT_ANDROID}/x86/share/gst-android/ndk-build/"
     include 'GStreamer.java'
     include 'androidmedia/GstAhcCallback.java'
-    include 'androidmedia/GstAhsCallback.java'
-    include 'androidmedia/GstAmcOnFrameAvailableListener.java'
     into layout.buildDirectory.dir('from-gst-android/org/freedesktop/gstreamer')
     filter(ReplaceTokens, tokens: [INCLUDE_CA_CERTIFICATES: '//', INCLUDE_FONTS: '//', INCLUDE_COPY_FILE: '//'])
 }
@@ -83,7 +81,7 @@ cargo {
         rustflag_list.add("-lc++abi")
         rustflag_list.add("-lffi -lz")
         rustflag_list.add("-liconv -lorc-0.4 -lgmodule-2.0 -lpcre2-8")
-        rustflag_list.add("-lgstcoreelements -lgstvideotestsrc -lgstautodetect -lgstvideo-1.0 -lgstapp")
+        rustflag_list.add("-lgstcoreelements -lgstvideo-1.0 -lgstapp")
         rustflag_list.add("-lgstopengl -lgstgl-1.0 -lgstcontroller-1.0 -lgraphene-1.0 -ljpeg -lpng16")
         rustflag_list.add("-lopenh264 -lgstopenh264 -lgstpbutils-1.0 -lgstvideoconvertscale")
         rustflag_list.add("-lgstandroidmedia -lgstaudio-1.0 -lgstphotography-1.0")

--- a/android/publisher/src/lib.rs
+++ b/android/publisher/src/lib.rs
@@ -347,7 +347,7 @@ fn create_pipeline() -> Result<gstreamer::Pipeline, VodaError> {
     )?;
     let topic = participant.create_topic::<Video>(
         "VideoStream",
-        "VideoStream",
+        "Video",
         QosKind::Default,
         None,
         NO_STATUS,

--- a/android/publisher/src/lib.rs
+++ b/android/publisher/src/lib.rs
@@ -337,7 +337,7 @@ unsafe extern "C" fn Java_com_s2e_1systems_MainActivity_nativeRun(_env: JNIEnv, 
 }
 
 fn create_pipeline() -> Result<gstreamer::Pipeline, VodaError> {
-    let pipeline_element = gstreamer::parse::launch("ahcsrc ! video/x-raw,framerate=[1/1,25/1],width=[1,1280],height=[1,720] ! tee name=t ! queue leaky=2 ! glimagesink t. ! queue leaky=2 max-size-buffers=1 ! videoconvert ! openh264enc complexity=0 scene-change-detection=0 background-detection=0 bitrate=1280000 ! appsink name=appsink max-buffers=1 sync=false")?;
+    let pipeline_element = gstreamer::parse::launch("ahcsrc ! video/x-raw,framerate=[1/1,25/1],width=[1,1280],height=[1,720] ! tee name=t ! queue leaky=2 max-size-buffers=1 ! glimagesink t. ! queue leaky=2 max-size-buffers=1 ! videoconvert ! openh264enc complexity=0 scene-change-detection=0 background-detection=0 bitrate=1280000 ! appsink name=appsink max-buffers=1 sync=false")?;
 
     let participant = DomainParticipantFactory::get_instance().create_participant(
         0,

--- a/android/publisher/src/lib.rs
+++ b/android/publisher/src/lib.rs
@@ -369,7 +369,11 @@ fn create_pipeline() -> Result<gstreamer::Pipeline, VodaError> {
         gstreamer_app::AppSinkCallbacks::builder()
             .new_sample(move |s| {
                 if let Ok(sample) = s.pull_sample() {
-                    let buffer_map = sample.buffer().unwrap().map_readable().unwrap();
+                    let buffer_map = sample
+                        .buffer()
+                        .expect("buffer exists")
+                        .map_readable()
+                        .expect("readable buffer");
                     let video_sample = Video {
                         user_id: 8,
                         frame_num: i,

--- a/android/subscriber/Cargo.toml
+++ b/android/subscriber/Cargo.toml
@@ -19,6 +19,6 @@ gstreamer-app = "0.22.0"
 gstreamer-video = "0.22.4"
 gstreamer-video-sys = "0.22.1"
 glib = "0.19.5"
-dust_dds = { version = "0.9" }
+dust_dds = { version = "0.10", git = "https://github.com/s2e-systems/dust-dds", branch = "main"}
 jni = { version = "0.21.1", default-features = false }
 ndk-sys = "0.6.0"

--- a/android/subscriber/build.gradle
+++ b/android/subscriber/build.gradle
@@ -12,9 +12,6 @@ tasks.register('configure_gstreamer_java', Copy) {
     // Note: all architectures have the same java template files
     from "${System.env.GSTREAMER_1_0_ROOT_ANDROID}/x86/share/gst-android/ndk-build/"
     include 'GStreamer.java'
-    include 'androidmedia/GstAhcCallback.java'
-    include 'androidmedia/GstAhsCallback.java'
-    include 'androidmedia/GstAmcOnFrameAvailableListener.java'
     into layout.buildDirectory.dir('from-gst-android/org/freedesktop/gstreamer')
     filter(ReplaceTokens, tokens: [INCLUDE_CA_CERTIFICATES: '//', INCLUDE_FONTS: '//', INCLUDE_COPY_FILE: '//'])
 }
@@ -82,11 +79,11 @@ cargo {
         rustflag_list.add("-lc++abi")
         rustflag_list.add("-L$gstreamer_android_root_path/$gstreamer_architecture/lib/gstreamer-1.0")
         rustflag_list.add("-lffi -lz -liconv -lorc-0.4 -lgmodule-2.0 -lpcre2-8")
-        rustflag_list.add("-lgstcoreelements -lgstvideotestsrc -lgstautodetect -lgstvideo-1.0 -lgstapp")
+        rustflag_list.add("-lgstvideo-1.0 -lgstapp")
         rustflag_list.add("-lgstopengl -lgstgl-1.0 -lgstcontroller-1.0 -lgraphene-1.0 -ljpeg -lpng16")
         rustflag_list.add("-lopenh264 -lgstopenh264 -lgstpbutils-1.0 -lgstvideoconvertscale")
-        rustflag_list.add("-lgstandroidmedia -lgstaudio-1.0 -lgstphotography-1.0")
-        rustflag_list.add("-lgstlibav -lavcodec -lavfilter -lavutil -lavformat -lswresample -lbz2")
+        //rustflag_list.add("-lgstandroidmedia -lgstaudio-1.0 -lgstphotography-1.0")
+//        rustflag_list.add("-lgstlibav -lavcodec -lavfilter -lavutil -lavformat -lswresample -lbz2")
         def rustflags = rustflag_list.join(" ")
         project.logger.info("RUSTFLAGS: $rustflags")
         spec.environment("RUSTFLAGS", rustflags)

--- a/android/subscriber/src/lib.rs
+++ b/android/subscriber/src/lib.rs
@@ -302,17 +302,13 @@ unsafe extern "C" fn Java_org_freedesktop_gstreamer_GStreamer_nativeInit(
     extern "C" {
         fn gst_plugin_opengl_register();
         fn gst_plugin_app_register();
-        fn gst_plugin_coreelements_register();
         fn gst_plugin_videoconvertscale_register();
-        fn gst_plugin_androidmedia_register();
         fn gst_plugin_openh264_register();
     }
 
     gst_plugin_opengl_register();
     gst_plugin_app_register();
-    gst_plugin_coreelements_register();
     gst_plugin_videoconvertscale_register();
-    gst_plugin_androidmedia_register();
     gst_plugin_openh264_register();
 }
 

--- a/android/subscriber/src/lib.rs
+++ b/android/subscriber/src/lib.rs
@@ -404,7 +404,7 @@ fn create_pipeline() -> Result<gstreamer::Pipeline, VodaError> {
     let participant = factory.create_participant(0, QosKind::Default, None, NO_STATUS)?;
     let topic = participant.create_topic::<Video>(
         "VideoStream",
-        "VideoStream",
+        "Video",
         QosKind::Default,
         None,
         NO_STATUS,

--- a/android/subscriber/src/lib.rs
+++ b/android/subscriber/src/lib.rs
@@ -56,10 +56,10 @@ impl From<dust_dds::infrastructure::error::DdsError> for VodaError {
 }
 
 #[derive(Debug, dust_dds::topic_definition::type_support::DdsType)]
-struct Video {
+struct Video<'a> {
     user_id: i16,
     frame_num: i32,
-    frame: Vec<u8>,
+    frame: &'a [u8],
 }
 
 static mut JAVA_VM: Option<JavaVM> = None;
@@ -347,8 +347,8 @@ struct Listener {
     appsrc: gstreamer_app::AppSrc,
 }
 
-impl DataReaderListener for Listener {
-    type Foo = Video;
+impl<'a> DataReaderListener<'a> for Listener {
+    type Foo = Video<'a>;
 
     fn on_data_available(
         &mut self,
@@ -371,7 +371,7 @@ impl DataReaderListener for Listener {
                         let buffer_ref = buffer.get_mut().expect("mutable buffer");
                         let mut buffer_samples =
                             buffer_ref.map_writable().expect("writeable buffer");
-                        buffer_samples.clone_from_slice(sample_data.frame.as_slice());
+                        buffer_samples.clone_from_slice(sample_data.frame);
                     }
                     self.appsrc
                         .push_buffer(buffer)

--- a/src/main_publisher.rs
+++ b/src/main_publisher.rs
@@ -5,10 +5,10 @@ use dust_dds::{
 use gstreamer::prelude::*;
 
 #[derive(Debug, dust_dds::topic_definition::type_support::DdsType)]
-struct Video {
+struct Video<'a> {
     user_id: i16,
     frame_num: i32,
-    frame: Vec<u8>,
+    frame: &'a [u8],
 }
 #[derive(Debug)]
 struct Error(String);
@@ -83,7 +83,7 @@ fn main() -> Result<(), Error> {
                     let video_sample = Video {
                         user_id: 8,
                         frame_num: i,
-                        frame: bytes.to_vec(),
+                        frame: bytes.as_slice(),
                     };
                     writer
                         .write(&video_sample, None)

--- a/src/main_publisher.rs
+++ b/src/main_publisher.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Error> {
         participant_factory.create_participant(domain_id, QosKind::Default, None, NO_STATUS)?;
     let topic = participant.create_topic::<Video>(
         "VideoStream",
-        "VideoStream",
+        "Video",
         QosKind::Default,
         None,
         NO_STATUS,

--- a/src/main_publisher.rs
+++ b/src/main_publisher.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Error> {
     let writer = publisher.create_datawriter(&topic, QosKind::Default, None, NO_STATUS)?;
 
     let pipeline = gstreamer::parse::launch(
-        r#"autovideosrc ! video/x-raw,framerate=[1/1,25/1],width=[1,1280],height=[1,720] ! tee name=t ! queue leaky=2 ! videoconvert ! openh264enc complexity=0 ! appsink name=appsink  t. ! queue leaky=2 ! taginject tags="title=Publisher" ! autovideosink"#,
+        r#"autovideosrc ! video/x-raw,framerate=[1/1,25/1],width=[1,1280],height=[1,720] ! tee name=t ! queue leaky=2 ! videoconvert ! openh264enc complexity=0 scene-change-detection=0 background-detection=0 bitrate=1280000 ! appsink name=appsink sync=false t. ! queue leaky=2 ! taginject tags="title=Publisher" ! autovideosink"#,
     )?;
 
     pipeline.set_state(gstreamer::State::Playing)?;

--- a/src/main_subscriber.rs
+++ b/src/main_subscriber.rs
@@ -13,10 +13,10 @@ use dust_dds::{
 use gstreamer::prelude::*;
 
 #[derive(Debug, dust_dds::topic_definition::type_support::DdsType)]
-struct Video {
+struct Video<'a> {
     user_id: i16,
     frame_num: i32,
-    frame: Vec<u8>,
+    frame: &'a [u8],
 }
 
 #[derive(Debug)]
@@ -51,8 +51,8 @@ struct Listener {
     appsrc: gstreamer_app::AppSrc,
 }
 
-impl DataReaderListener for Listener {
-    type Foo = Video;
+impl<'a> DataReaderListener<'a> for Listener {
+    type Foo = Video<'a>;
 
     fn on_data_available(
         &mut self,
@@ -71,7 +71,7 @@ impl DataReaderListener for Listener {
                         let buffer_ref = buffer.get_mut().expect("mutable buffer");
                         let mut buffer_samples =
                             buffer_ref.map_writable().expect("writeable buffer");
-                        buffer_samples.clone_from_slice(sample_data.frame.as_slice());
+                        buffer_samples.clone_from_slice(sample_data.frame);
                     }
                     self.appsrc
                         .push_buffer(buffer)

--- a/src/main_subscriber.rs
+++ b/src/main_subscriber.rs
@@ -94,7 +94,7 @@ fn main() -> Result<(), Error> {
         participant_factory.create_participant(domain_id, QosKind::Default, None, NO_STATUS)?;
     let topic = participant.create_topic::<Video>(
         "VideoStream",
-        "VideoStream",
+        "Video",
         QosKind::Default,
         None,
         NO_STATUS,


### PR DESCRIPTION
Use version 0.10 of Dust DDS in all publisher and subscribers. Use a reference in the data of the Video struct in all publisher and subscribers. Remove some unnecessary dependencies in all publisher and subscribers.